### PR TITLE
feat: install and run update-ca-certificates on all base images

### DIFF
--- a/.github/workflows/container_branches.yml
+++ b/.github/workflows/container_branches.yml
@@ -22,9 +22,9 @@ jobs:
       - name: dagger=product
         id: config
         run: |
-          # write your own scoped version of the following since https://github.com/bradfordwagner/dagger-container-builds@feat/mirror-commands is not available at this base level
+          # write your own scoped version of the following since https://github.com/bradfordwagner/dagger-container-builds@0.3.0 is not available at this base level
           set -x
-          echo product=$(./bin/dagger -m https://github.com/bradfordwagner/dagger-container-builds@feat/mirror-commands call product-json --src=. --version=${{ env.version }}) >> $GITHUB_OUTPUT
+          echo product=$(./bin/dagger -m https://github.com/bradfordwagner/dagger-container-builds@0.3.0 call product-json --src=. --version=${{ env.version }}) >> $GITHUB_OUTPUT
   builds:
     runs-on: ${{ matrix.product.runner }}
     permissions: write-all
@@ -57,7 +57,7 @@ jobs:
       - name: dagger=build
         id: config
         run: |
-          ./bin/dagger -m https://github.com/bradfordwagner/dagger-container-builds@feat/mirror-commands call build \
+          ./bin/dagger -m https://github.com/bradfordwagner/dagger-container-builds@0.3.0 call build \
             --progress=plain \
             --src=. \
             --index=${{ matrix.product.index }} \
@@ -93,7 +93,7 @@ jobs:
         id: config
         run: |
           set -x
-          ./bin/dagger -m https://github.com/bradfordwagner/dagger-container-builds@feat/mirror-commands call manifest \
+          ./bin/dagger -m https://github.com/bradfordwagner/dagger-container-builds@0.3.0 call manifest \
             --src=. \
             --version=${version} \
             --actor=env:actor \

--- a/.github/workflows/container_branches.yml
+++ b/.github/workflows/container_branches.yml
@@ -22,9 +22,9 @@ jobs:
       - name: dagger=product
         id: config
         run: |
-          # write your own scoped version of the following since https://github.com/bradfordwagner/dagger-container-builds@0.1.1 is not available at this base level
+          # write your own scoped version of the following since https://github.com/bradfordwagner/dagger-container-builds@feat/mirror-commands is not available at this base level
           set -x
-          echo product=$(./bin/dagger -m https://github.com/bradfordwagner/dagger-container-builds@0.1.1 call product-json --src=. --version=${{ env.version }}) >> $GITHUB_OUTPUT
+          echo product=$(./bin/dagger -m https://github.com/bradfordwagner/dagger-container-builds@feat/mirror-commands call product-json --src=. --version=${{ env.version }}) >> $GITHUB_OUTPUT
   builds:
     runs-on: ${{ matrix.product.runner }}
     permissions: write-all
@@ -57,7 +57,7 @@ jobs:
       - name: dagger=build
         id: config
         run: |
-          ./bin/dagger -m https://github.com/bradfordwagner/dagger-container-builds@0.1.1 call build \
+          ./bin/dagger -m https://github.com/bradfordwagner/dagger-container-builds@feat/mirror-commands call build \
             --progress=plain \
             --src=. \
             --index=${{ matrix.product.index }} \
@@ -93,7 +93,7 @@ jobs:
         id: config
         run: |
           set -x
-          ./bin/dagger -m https://github.com/bradfordwagner/dagger-container-builds@0.1.1 call manifest \
+          ./bin/dagger -m https://github.com/bradfordwagner/dagger-container-builds@feat/mirror-commands call manifest \
             --src=. \
             --version=${version} \
             --actor=env:actor \

--- a/.github/workflows/container_tags.yml
+++ b/.github/workflows/container_tags.yml
@@ -19,9 +19,9 @@ jobs:
       - name: dagger=product
         id: config
         run: |
-          # write your own scoped version of the following since https://github.com/bradfordwagner/dagger-container-builds@feat/mirror-commands is not available at this base level
+          # write your own scoped version of the following since https://github.com/bradfordwagner/dagger-container-builds@0.3.0 is not available at this base level
           set -x
-          echo product=$(./bin/dagger -m https://github.com/bradfordwagner/dagger-container-builds@feat/mirror-commands call product-json --src=. --version=${{ env.version }}) >> $GITHUB_OUTPUT
+          echo product=$(./bin/dagger -m https://github.com/bradfordwagner/dagger-container-builds@0.3.0 call product-json --src=. --version=${{ env.version }}) >> $GITHUB_OUTPUT
   builds:
     runs-on: ${{ matrix.product.runner }}
     permissions: write-all
@@ -54,7 +54,7 @@ jobs:
       - name: dagger=build
         id: config
         run: |
-          ./bin/dagger -m https://github.com/bradfordwagner/dagger-container-builds@feat/mirror-commands call build \
+          ./bin/dagger -m https://github.com/bradfordwagner/dagger-container-builds@0.3.0 call build \
             --progress=plain \
             --src=. \
             --index=${{ matrix.product.index }} \
@@ -90,7 +90,7 @@ jobs:
         id: config
         run: |
           set -x
-          ./bin/dagger -m https://github.com/bradfordwagner/dagger-container-builds@feat/mirror-commands call manifest \
+          ./bin/dagger -m https://github.com/bradfordwagner/dagger-container-builds@0.3.0 call manifest \
             --src=. \
             --version=${version} \
             --actor=env:actor \

--- a/.github/workflows/container_tags.yml
+++ b/.github/workflows/container_tags.yml
@@ -19,9 +19,9 @@ jobs:
       - name: dagger=product
         id: config
         run: |
-          # write your own scoped version of the following since https://github.com/bradfordwagner/dagger-container-builds@0.1.1 is not available at this base level
+          # write your own scoped version of the following since https://github.com/bradfordwagner/dagger-container-builds@feat/mirror-commands is not available at this base level
           set -x
-          echo product=$(./bin/dagger -m https://github.com/bradfordwagner/dagger-container-builds@0.1.1 call product-json --src=. --version=${{ env.version }}) >> $GITHUB_OUTPUT
+          echo product=$(./bin/dagger -m https://github.com/bradfordwagner/dagger-container-builds@feat/mirror-commands call product-json --src=. --version=${{ env.version }}) >> $GITHUB_OUTPUT
   builds:
     runs-on: ${{ matrix.product.runner }}
     permissions: write-all
@@ -54,7 +54,7 @@ jobs:
       - name: dagger=build
         id: config
         run: |
-          ./bin/dagger -m https://github.com/bradfordwagner/dagger-container-builds@0.1.1 call build \
+          ./bin/dagger -m https://github.com/bradfordwagner/dagger-container-builds@feat/mirror-commands call build \
             --progress=plain \
             --src=. \
             --index=${{ matrix.product.index }} \
@@ -90,7 +90,7 @@ jobs:
         id: config
         run: |
           set -x
-          ./bin/dagger -m https://github.com/bradfordwagner/dagger-container-builds@0.1.1 call manifest \
+          ./bin/dagger -m https://github.com/bradfordwagner/dagger-container-builds@feat/mirror-commands call manifest \
             --src=. \
             --version=${version} \
             --actor=env:actor \

--- a/config.yaml
+++ b/config.yaml
@@ -7,50 +7,68 @@ builds:
       archs:
         - linux/amd64
         - linux/arm64
+      commands:
+        - /tmp/build/scripts/alpine.sh
     - repo: alpine
       repo_override: ""
       tag: "3.23"
       archs:
         - linux/amd64
         - linux/arm64
+      commands:
+        - /tmp/build/scripts/alpine.sh
     - repo: archlinux
       repo_override: ""
       tag: latest
       archs:
         - linux/amd64
+      commands:
+        - /tmp/build/scripts/archlinux.sh
     - repo: debian
       repo_override: ""
       tag: bookworm
       archs:
         - linux/amd64
         - linux/arm64
+      commands:
+        - /tmp/build/scripts/debian.sh
     - repo: debian
       repo_override: ""
       tag: bookworm-slim
       archs:
         - linux/amd64
         - linux/arm64
+      commands:
+        - /tmp/build/scripts/debian.sh
     - repo: debian
       repo_override: ""
       tag: trixie
       archs:
         - linux/amd64
         - linux/arm64
+      commands:
+        - /tmp/build/scripts/debian.sh
     - repo: debian
       repo_override: ""
       tag: trixie-slim
       archs:
         - linux/amd64
         - linux/arm64
+      commands:
+        - /tmp/build/scripts/debian.sh
     - repo: ubuntu
       repo_override: ""
       tag: noble
       archs:
         - linux/amd64
         - linux/arm64
+      commands:
+        - /tmp/build/scripts/debian.sh
     - repo: ubuntu
       repo_override: ""
       tag: plucky
       archs:
         - linux/amd64
         - linux/arm64
+      commands:
+        - /tmp/build/scripts/debian.sh

--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,7 @@ builds:
         - linux/amd64
         - linux/arm64
       commands:
-        - /tmp/build/scripts/alpine.sh
+        - scripts/alpine.sh
     - repo: alpine
       repo_override: ""
       tag: "3.23"
@@ -16,14 +16,14 @@ builds:
         - linux/amd64
         - linux/arm64
       commands:
-        - /tmp/build/scripts/alpine.sh
+        - scripts/alpine.sh
     - repo: archlinux
       repo_override: ""
       tag: latest
       archs:
         - linux/amd64
       commands:
-        - /tmp/build/scripts/archlinux.sh
+        - scripts/archlinux.sh
     - repo: debian
       repo_override: ""
       tag: bookworm
@@ -31,7 +31,7 @@ builds:
         - linux/amd64
         - linux/arm64
       commands:
-        - /tmp/build/scripts/debian.sh
+        - scripts/debian.sh
     - repo: debian
       repo_override: ""
       tag: bookworm-slim
@@ -39,7 +39,7 @@ builds:
         - linux/amd64
         - linux/arm64
       commands:
-        - /tmp/build/scripts/debian.sh
+        - scripts/debian.sh
     - repo: debian
       repo_override: ""
       tag: trixie
@@ -47,7 +47,7 @@ builds:
         - linux/amd64
         - linux/arm64
       commands:
-        - /tmp/build/scripts/debian.sh
+        - scripts/debian.sh
     - repo: debian
       repo_override: ""
       tag: trixie-slim
@@ -55,7 +55,7 @@ builds:
         - linux/amd64
         - linux/arm64
       commands:
-        - /tmp/build/scripts/debian.sh
+        - scripts/debian.sh
     - repo: ubuntu
       repo_override: ""
       tag: noble
@@ -63,7 +63,7 @@ builds:
         - linux/amd64
         - linux/arm64
       commands:
-        - /tmp/build/scripts/debian.sh
+        - scripts/debian.sh
     - repo: ubuntu
       repo_override: ""
       tag: plucky
@@ -71,4 +71,4 @@ builds:
         - linux/amd64
         - linux/arm64
       commands:
-        - /tmp/build/scripts/debian.sh
+        - scripts/debian.sh

--- a/scripts/alpine.sh
+++ b/scripts/alpine.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 set -e
 apk add --no-cache ca-certificates
-which update-ca-certificates
 update-ca-certificates

--- a/scripts/alpine.sh
+++ b/scripts/alpine.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+apk add --no-cache ca-certificates
+update-ca-certificates

--- a/scripts/alpine.sh
+++ b/scripts/alpine.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 set -e
 apk add --no-cache ca-certificates
+which update-ca-certificates
 update-ca-certificates

--- a/scripts/archlinux.sh
+++ b/scripts/archlinux.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 set -e
 pacman -S --noconfirm ca-certificates
-which update-ca-certificates
 update-ca-certificates

--- a/scripts/archlinux.sh
+++ b/scripts/archlinux.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
-pacman -S --noconfirm ca-certificates-utils
+pacman -Sy --noconfirm ca-certificates-utils
 update-ca-certificates

--- a/scripts/archlinux.sh
+++ b/scripts/archlinux.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
-pacman -Sy --noconfirm ca-certificates-utils
-update-ca-certificates
+pacman -Sy --noconfirm --needed --disable-sandbox ca-certificates-utils
+update-ca-trust

--- a/scripts/archlinux.sh
+++ b/scripts/archlinux.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+pacman -S --noconfirm ca-certificates
+update-ca-certificates

--- a/scripts/archlinux.sh
+++ b/scripts/archlinux.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
-pacman -S --noconfirm ca-certificates
+pacman -S --noconfirm ca-certificates-utils
 update-ca-certificates

--- a/scripts/archlinux.sh
+++ b/scripts/archlinux.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 set -e
 pacman -S --noconfirm ca-certificates
+which update-ca-certificates
 update-ca-certificates

--- a/scripts/debian.sh
+++ b/scripts/debian.sh
@@ -3,5 +3,4 @@ set -e
 apt-get update
 apt-get install -y ca-certificates
 rm -rf /var/lib/apt/lists/*
-which update-ca-certificates
 update-ca-certificates

--- a/scripts/debian.sh
+++ b/scripts/debian.sh
@@ -3,4 +3,5 @@ set -e
 apt-get update
 apt-get install -y ca-certificates
 rm -rf /var/lib/apt/lists/*
+which update-ca-certificates
 update-ca-certificates

--- a/scripts/debian.sh
+++ b/scripts/debian.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+apt-get update
+apt-get install -y ca-certificates
+rm -rf /var/lib/apt/lists/*
+update-ca-certificates


### PR DESCRIPTION
## Summary

- Adds `commands` support to the mirror flavor via [dagger-container-builds@feat/mirror-commands](https://github.com/bradfordwagner/dagger-container-builds/tree/feat/mirror-commands)
- Adds OS-specific scripts under `scripts/` that install ca-certificates and invoke the appropriate update command
- Updates `config.yaml` to wire each build entry to its script

## OS command mapping

| OS | Package | Command |
|---|---|---|
| Alpine | `ca-certificates` | `update-ca-certificates` |
| Debian / Ubuntu | `ca-certificates` | `update-ca-certificates` |
| Arch Linux | `ca-certificates-utils` | `update-ca-trust` |

## Size delta vs 4.3.2

| Image | 4.3.2 | latest | diff |
|---|---|---|---|
| alpine_3.22 | 3.6 MB | 3.9 MB | +284 KB |
| alpine_3.23 | 3.6 MB | 3.9 MB | +284 KB |
| debian_bookworm | 46.2 MB | 50.9 MB | +4.6 MB |
| debian_bookworm-slim | 26.9 MB | 30.2 MB | +3.3 MB |
| debian_trixie | 47.0 MB | 49.2 MB | +2.2 MB |
| debian_trixie-slim | 28.4 MB | 29.5 MB | +1.1 MB |
| ubuntu_noble | 28.3 MB | 29.3 MB | +1.0 MB |
| ubuntu_plucky | 28.3 MB | 29.4 MB | +1.0 MB |
| archlinux_latest | n/a | 134.5 MB | n/a |

## Test plan

- [x] CI passing on `feat/mirror-commands`
- [x] All 9 images verified to have the update command installed via `docker run`