### PR TITLE
feat: install git across all base image variants with test

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,6 +9,7 @@ builds:
         - linux/arm64
       commands:
         - scripts/alpine.sh
+        - scripts/test.sh
     - repo: alpine
       repo_override: ""
       tag: "3.23"
@@ -17,6 +18,7 @@ builds:
         - linux/arm64
       commands:
         - scripts/alpine.sh
+        - scripts/test.sh
     - repo: archlinux
       repo_override: ""
       tag: latest
@@ -24,6 +26,7 @@ builds:
         - linux/amd64
       commands:
         - scripts/archlinux.sh
+        - scripts/test.sh
     - repo: debian
       repo_override: ""
       tag: bookworm
@@ -32,6 +35,7 @@ builds:
         - linux/arm64
       commands:
         - scripts/debian.sh
+        - scripts/test.sh
     - repo: debian
       repo_override: ""
       tag: bookworm-slim
@@ -40,6 +44,7 @@ builds:
         - linux/arm64
       commands:
         - scripts/debian.sh
+        - scripts/test.sh
     - repo: debian
       repo_override: ""
       tag: trixie
@@ -48,6 +53,7 @@ builds:
         - linux/arm64
       commands:
         - scripts/debian.sh
+        - scripts/test.sh
     - repo: debian
       repo_override: ""
       tag: trixie-slim
@@ -56,6 +62,7 @@ builds:
         - linux/arm64
       commands:
         - scripts/debian.sh
+        - scripts/test.sh
     - repo: ubuntu
       repo_override: ""
       tag: noble
@@ -64,6 +71,7 @@ builds:
         - linux/arm64
       commands:
         - scripts/debian.sh
+        - scripts/test.sh
     - repo: ubuntu
       repo_override: ""
       tag: plucky
@@ -72,3 +80,4 @@ builds:
         - linux/arm64
       commands:
         - scripts/debian.sh
+        - scripts/test.sh

--- a/scripts/alpine.sh
+++ b/scripts/alpine.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
-apk add --no-cache ca-certificates
+apk add --no-cache ca-certificates git
 update-ca-certificates

--- a/scripts/archlinux.sh
+++ b/scripts/archlinux.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
-pacman -Sy --noconfirm --needed --disable-sandbox ca-certificates-utils
+pacman -Sy --noconfirm --needed --disable-sandbox ca-certificates-utils git
 update-ca-trust

--- a/scripts/debian.sh
+++ b/scripts/debian.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
 apt-get update
-apt-get install -y ca-certificates
+apt-get install -y ca-certificates git
 rm -rf /var/lib/apt/lists/*
 update-ca-certificates

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+git --version


### PR DESCRIPTION
## Summary

- Add `git` to `debian.sh`, `alpine.sh`, and `archlinux.sh` covering all 9 OS variants
- Add `scripts/test.sh` that runs `git --version` and wire it into every build's `commands` list

## Test plan

- [x] All 19 build jobs passed across alpine, archlinux, debian, and ubuntu variants
- [x] Manifest job passed